### PR TITLE
fix a wrong url reference path in guide index page

### DIFF
--- a/source/guide/index.md
+++ b/source/guide/index.md
@@ -85,7 +85,7 @@ Weex supports [Vue.js](https://vuejs.org/) and [Rax](https://alibaba.github.io/r
 
 > Vue.js and Rax are already integrated into Weex SDK, you don't need to require them manually.
 
-However, Vue and Rax are not the only options, it's possible to integrate other your favorite front-end framework into Weex. There is a document *[Extend JS Framework](./advanced/extend-js-framework.html)* that describes how to implement it, but the process is still very complicated and tricky. To achieve it, you need to understand many underlying details about the js-native bridge and native render engines.
+However, Vue and Rax are not the only options, it's possible to integrate other your favorite front-end framework into Weex. There is a document *[Extend JS Framework](./extend-js-framework.html)* that describes how to implement it, but the process is still very complicated and tricky. To achieve it, you need to understand many underlying details about the js-native bridge and native render engines.
 
 You can read *[Front-End Frameworks](./front-end-frameworks.html)* to learn more details.
 


### PR DESCRIPTION
The extending JS Framework source at `line 88` in the `guide/index.md` went wrong.
Using the previous reference will get a `404` at the current live version of the site.
Fixed by change this reference to the correct location.