### PR TITLE
fix link for <a> and <div> docs

### DIFF
--- a/docs/docs/components/a.md
+++ b/docs/docs/components/a.md
@@ -6,6 +6,8 @@ order: 8.01
 version: 2.1
 ---
 
+## Introduction
+
 `<a>` is mainly used for navigation between weex pages。
 
 > **Note:** The behavior of `<a>` is similar to [`<div>`](./div.html) except for the aspect mentioned in current page.
@@ -22,18 +24,15 @@ Wrap the element navigating from with `<a>`
 Refer the [demo](http://dotwe.org/vue/1cec564d6e25c169a0a9a92db3a00955).
 
 ## Attributes:
-| Attribute       | Type    |Value| Default Value|
-| -------------   | ------  | --- | ------------ |
-| `href` | String | {URL}   | -   | -            |
 
-### `href`
-`href` defines the URL that current page will navigate. `href` **must** point to a weex page, the behavior of other case is **undefined**.
+
+* **href** String ,`href` defines the URL that current page will navigate. `href` **must** point to a weex page, the behavior of other case is **undefined**.
 
 ## Style
-Support [common styles](../../wiki/common-styles.html).
+Support [common styles](../styles/common-styles.html).
 
 ## Events
-Support [common events](../../wiki/common-events.html)
+Support [common events](../events/common-events.html)
 
 ### `click`
 > **Notes:** The execution order of callback function of click and href is **undefined**. Do **not** use click event to do the preprocessing of `href`.

--- a/docs/docs/components/div.md
+++ b/docs/docs/components/div.md
@@ -2,7 +2,6 @@
 
 `<div>` is a base container component.support all 
 
-- [common attributes](/wiki/common-attributes.html).
 - [common styles](/wiki/common-styles.html)
 - [common events](/wiki/common-events.html)
 - flexbox layout
@@ -15,14 +14,14 @@ similar to `div` in `html`
 
 ## Attributes
 
-* **common attributes**. Check out [common attributes](/wiki/common-attributes.html).
+* **common attributes**. 
 
 ## Styles
 
-* **common styles**. Check out [common styles](/wiki/common-styles.html).
+* **common styles**. support [common styles](../styles/common-styles.html).
 
 ## Events
-* **common events**. Check out the [common events](/wiki/common-events.html).
+* **common events**. support [common events](../events/common-events.html).
 
 ## Other
 

--- a/docs/zh/docs/components/a.md
+++ b/docs/zh/docs/components/a.md
@@ -9,11 +9,11 @@
 
 ## 样式
 
-* **通用样式**. 参见[通用样式](/wiki/common-styles.html).
+* **通用样式**. 参见[通用样式](../styles/common-styles.html).
 
 ## 事件
 
-* **通用事件**. 参见[通用事件](/wiki/common-events.html)
+* **通用事件**. 参见[通用事件](../events/common-events.html)
 
 ## 其它
 

--- a/docs/zh/docs/components/div.md
+++ b/docs/zh/docs/components/div.md
@@ -8,15 +8,15 @@
 
 ## 属性
 
-* **通用属性**. 参见[通用属性](/wiki/common-attributes.html).
+* **通用属性**. 
 
 ## 样式
 
-* **通用样式**. 参见[通用样式](/wiki/common-styles.html).
+* **通用样式**. 参见[通用样式](../styles/common-styles.html).
 
 ## 事件
 
-* **通用事件**. 参见[通用事件](/wiki/common-events.html).
+* **通用事件**. 参见[通用事件](../events/common-events.html).
 
 ## 其它
 


### PR DESCRIPTION
fix link error  for \<a\> and \<div\> docs