### PR TITLE
add @objc note for extending module using swift

### DIFF
--- a/docs/guide/extend/extend-ios-with-swift.md
+++ b/docs/guide/extend/extend-ios-with-swift.md
@@ -16,14 +16,13 @@ a complete [demo](https://github.com/acton393/WeexSwiftSample.git)
 - implementation in `WXSwiftTestModule.h/m`
   - WXSwiftTestModule.h
     
-    ```
-        #import <Foundation/Foundation.h>
-        #import <WeexSDK/WeexSDK.h>
+    ```swift
+    #import <Foundation/Foundation.h>
+    #import <WeexSDK/WeexSDK.h>
     
-        @interface WXSwiftTestModule : NSObject <WXModuleProtocol>
+    @interface WXSwiftTestModule : NSObject <WXModuleProtocol>
     
-        @end
-    
+    @end
     ```
   - WXSwiftTestModule.m
     
@@ -34,20 +33,19 @@ a complete [demo](https://github.com/acton393/WeexSwiftSample.git)
     weex/ios/playground/DerivedData/WeexDemo/Build/Intermediates/WeexDemo.build/Debug-iphonesimulator/WeexDemo.build/DerivedSources/WeexDemo-Swift.h
     ```
     export method define in swift file.
-    ```
-        #import "WXSwiftTestModule.h"
-        #import "WeexDemo-Swift.h" // you need to import the header to make Objective-C code recognize the method defined in swift file.
+    ```swift
+    #import "WXSwiftTestModule.h"
+    #import "WeexDemo-Swift.h" // you need to import the header to make Objective-C code recognize the method defined in swift file.
     
-        @implementation WXSwiftTestModule
-        #pragma clang diagnostic push //forbid unknow selector warrning
-        #pragma clang diagnostic ignored "-Wundeclared-selector"
+    @implementation WXSwiftTestModule
+    #pragma clang diagnostic push //forbid unknow selector warrning
+    #pragma clang diagnostic ignored "-Wundeclared-selector"
     
-        WX_EXPORT_METHOD(@selector(printSome:callback:)) //method name in Swift, you can get the final method name in `WeexDemo-Swift.h` as the convert of Xcode.
+    WX_EXPORT_METHOD(@selector(printSome:callback:)) //method name in Swift, you can get the final method name in `WeexDemo-Swift.h` as the convert of Xcode.
 
-        #pragma clang diagnostic pop
+    #pragma clang diagnostic pop
     
-        @end
-    
+    @end
     ```
 - in Swift
   make an extension for Objective-C class `WXSwiftTestModule`, add a method, and then export it in Objective-C, then we can use it in javaScript.
@@ -55,14 +53,14 @@ a complete [demo](https://github.com/acton393/WeexSwiftSample.git)
   - WXSwiftTestModule.swift
     
     ```swift
-        import Foundation
-        public extension WXSwiftTestModule {
-          @objc(printSome:callback:)
-          public func printSome(someThing:String, callback:WXModuleCallback) {
-            print(someThing)
-            callback(someThing)
-          }
-        }
+    import Foundation
+    public extension WXSwiftTestModule {
+      @objc(printSome:callback:)
+      public func printSome(someThing:String, callback:WXModuleCallback) {
+        print(someThing)
+        callback(someThing)
+      }
+    }
     ```
     
   we need to expose `WXSwiftTestModule` `WXModuleCallback` in `WeexDemo-Bridging-Header` as our `Objective-C` need to access them.
@@ -73,7 +71,7 @@ a complete [demo](https://github.com/acton393/WeexSwiftSample.git)
 
   - WeexDemo-Bridging-Header.h
     
-    ```
+    ```swift
     //
     //  Use this file to import your target's public headers that you would like to expose to Swift.
     //
@@ -86,26 +84,25 @@ a complete [demo](https://github.com/acton393/WeexSwiftSample.git)
   ### module usage
   - register module to WeexSDK
 
-    ```
+    ```Objective-C
     [WXSDKEngine registerModule:@"swifter" withClass:[WXSwiftTestModule class]];
     
     ```
   - front-end usage
 
-    ```
-      <template>
-          <text>Swift Module</text>
-      </template>
+    ```html
+    <template>
+      <text>Swift Module</text>
+    </template>
     
-      <script>
-        module.exports = {
-          ready: function() {
-            var swifter = weex.require('swifter');
-            swifter.printSome("https://www.taobao.com",function(param){
-              nativeLog(param);
-            });
-          }
-    
-        };
-      </script>
+    <script>
+      module.exports = {
+        ready: function() {
+          var swifter = weex.require('swifter');
+          swifter.printSome("https://www.taobao.com",function(param){
+            nativeLog(param);
+          });
+        }
+      };
+    </script>
     ```

--- a/docs/guide/extend/extend-ios-with-swift.md
+++ b/docs/guide/extend/extend-ios-with-swift.md
@@ -54,17 +54,22 @@ a complete [demo](https://github.com/acton393/WeexSwiftSample.git)
 
   - WXSwiftTestModule.swift
     
-    ```
+    ```swift
         import Foundation
         public extension WXSwiftTestModule {
-           public func printSome(someThing:String, callback:WXModuleCallback) {
-               print(someThing)
-               callback(someThing)
-           }
+          @objc(printSome:callback:)
+          public func printSome(someThing:String, callback:WXModuleCallback) {
+            print(someThing)
+            callback(someThing)
+          }
         }
     ```
     
-  we need to expose `WXSwiftTestModule` `WXModuleCallback` in `WeexDemo-Bridging-Header` as our `Objective-C` need to access them
+  we need to expose `WXSwiftTestModule` `WXModuleCallback` in `WeexDemo-Bridging-Header` as our `Objective-C` need to access them.
+
+  Attention: Please add the `@objc` attribute to the method in the Swift file to avoid the error for the method cannot be found.
+
+
 
   - WeexDemo-Bridging-Header.h
     

--- a/docs/zh/guide/extend/extend-ios-with-swift.md
+++ b/docs/zh/guide/extend/extend-ios-with-swift.md
@@ -51,17 +51,21 @@
   扩展 OC 的类 `WXSwiftTestModule`,增加了一个方法，这个方法就是我们要暴露出来，在 js 中可以调到的
   - WXSwiftTestModule.swift
     
-    ```
+    ```swift
         import Foundation
         public extension WXSwiftTestModule {
-           public func printSome(someThing:String, callback:WXModuleCallback) {
-               print(someThing)
-               callback(someThing)
-           }
+          @objc(printSome:callback:)
+          public func printSome(someThing:String, callback:WXModuleCallback) {
+            print(someThing)
+            callback(someThing)
+          }
         }
     ```
     
-    `WXSwiftTestModule` 和`WXModuleCallback` 因为是 OC 的，需要在 `WeexDemo-Bridging-Header` 中暴露
+    `WXSwiftTestModule` 和`WXModuleCallback` 因为是 OC 的，需要在 `WeexDemo-Bridging-Header` 中暴露。
+
+    注意：请在 Swift 文件中为方法添加 `@objc` 修饰符，避免找不到方法的报错。
+
   - WeexDemo-Bridging-Header.h中
     
     ```

--- a/docs/zh/guide/extend/extend-ios-with-swift.md
+++ b/docs/zh/guide/extend/extend-ios-with-swift.md
@@ -13,14 +13,13 @@
 - `WXSwiftTestModule.h/m`中实现
   - WXSwiftTestModule.h 中
     
-    ```
-        #import <Foundation/Foundation.h>
-        #import <WeexSDK/WeexSDK.h>
+    ```swift
+    #import <Foundation/Foundation.h>
+    #import <WeexSDK/WeexSDK.h>
     
-        @interface WXSwiftTestModule : NSObject <WXModuleProtocol>
+    @interface WXSwiftTestModule : NSObject <WXModuleProtocol>
     
-        @end
-    
+    @end
     ```
   - WXSwiftTestModule.m 中
     
@@ -32,34 +31,33 @@
     
     路径具体需要根据自己工程而定
     
-    ```
-        #import "WXSwiftTestModule.h"
-        #import "WeexDemo-Swift.h" // Swift类和方法 被 `Objective-C` 识别需要导入
+    ```swift
+    #import "WXSwiftTestModule.h"
+    #import "WeexDemo-Swift.h" // Swift类和方法 被 `Objective-C` 识别需要导入
     
-        @implementation WXSwiftTestModule
-        #pragma clang diagnostic push //关闭unknow selector的warrning
-        #pragma clang diagnostic ignored "-Wundeclared-selector"
+    @implementation WXSwiftTestModule
+    #pragma clang diagnostic push //关闭unknow selector的warrning
+    #pragma clang diagnostic ignored "-Wundeclared-selector"
     
-        WX_EXPORT_METHOD(@selector(printSome:callback:)) //Swift 中定义的方法，XCode 转换成的最终的方法名称，在`WeexDemo-Swift.h`里面查看
+    WX_EXPORT_METHOD(@selector(printSome:callback:)) //Swift 中定义的方法，XCode 转换成的最终的方法名称，在`WeexDemo-Swift.h`里面查看
     
-        #pragma clang diagnostic pop
+    #pragma clang diagnostic pop
     
-        @end
-    
+    @end
     ```
 - Swift 中实现 
   扩展 OC 的类 `WXSwiftTestModule`,增加了一个方法，这个方法就是我们要暴露出来，在 js 中可以调到的
   - WXSwiftTestModule.swift
     
     ```swift
-        import Foundation
-        public extension WXSwiftTestModule {
-          @objc(printSome:callback:)
-          public func printSome(someThing:String, callback:WXModuleCallback) {
-            print(someThing)
-            callback(someThing)
-          }
-        }
+    import Foundation
+    public extension WXSwiftTestModule {
+      @objc(printSome:callback:)
+      public func printSome(someThing:String, callback:WXModuleCallback) {
+        print(someThing)
+        callback(someThing)
+      }
+    }
     ```
     
     `WXSwiftTestModule` 和`WXModuleCallback` 因为是 OC 的，需要在 `WeexDemo-Bridging-Header` 中暴露。
@@ -81,26 +79,25 @@
   ### module 使用
   - 注册 module 
     
-    ```
+    ```Objective-C
     [WXSDKEngine registerModule:@"swifter" withClass:[WXSwiftTestModule class]];
     
     ```
   - 前端脚本中用法
     
-    ```
-      <template>
-          <text>Swift Module</text>
-      </template>
+    ```html
+    <template>
+      <text>Swift Module</text>
+    </template>
     
-      <script>
-        module.exports = {
-          ready: function() {
-            var swifter = weex.require('swifter');
-            swifter.printSome("https://www.taobao.com",function(param){
-              nativeLog(param);
-            });
-          }
-    
-        };
-      </script>
+    <script>
+      module.exports = {
+        ready: function() {
+          var swifter = weex.require('swifter');
+          swifter.printSome("https://www.taobao.com",function(param){
+            nativeLog(param);
+          });
+        }
+      };
+    </script>
     ```


### PR DESCRIPTION
1. add `@objc` note to fix [issues - 使用swift 扩展weex module](https://github.com/weexteam/article/issues/55)
2. add a highlight for swift code and optimize code format
